### PR TITLE
🔍️ feat: Add article SEO

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -26,6 +26,8 @@ class CasperTheGhostDotMe extends Document {
 
           <meta name="twitter:card" content="summary" />
           <meta name="twitter:creator" content="@casper124578" />
+
+          <meta name="author" content="Casper Iversen" />
         </Head>
         <body>
           <script>0</script>

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -46,6 +46,10 @@ const PostPage = ({ post }: Props) => {
       />
       <Head>
         <link rel="preload" href="/fonts/CascadiaMono.woff2" as="font" type="font/woff2" />
+
+        {/* why not "author": https://github.com/postlight/mercury-parser/blob/HEAD/src/extractors/generic/author/constants.js#L5 */}
+        <meta name="authors" content="Casper Iversen" />
+        <meta name="created" content={post.createdAt} />
       </Head>
 
       <BlogHeader post={post} />

--- a/src/pages/snippets/[slug].tsx
+++ b/src/pages/snippets/[slug].tsx
@@ -37,6 +37,9 @@ const PostPage = ({ snippet }: Props) => {
       />
       <Head>
         <link rel="preload" href="/fonts/CascadiaMono.woff2" as="font" type="font/woff2" />
+
+        <meta name="authors" content="Casper Iversen" />
+        <meta name="created" content={snippet.createdAt} />
       </Head>
 
       <BlogHeader post={snippet} />


### PR DESCRIPTION
Hey Casper! Since your blog does not have RSS, I was using it to test the isolated article feature for Zyndicate :smile:

By using [Mercury Web Parser](https://mercury.postlight.com/web-parser/), I've noticed that information as `author` and `date_published` was not working. See:

![image](https://user-images.githubusercontent.com/60361387/122101160-5fe7cc00-cdea-11eb-96a9-fdbf5e03f6ea.png)

Then, on the Mercury's source code, I found the metatags which they are using to define these and added from the `post` object.

Now, it should be like this:

![image](https://user-images.githubusercontent.com/60361387/122101748-1055d000-cdeb-11eb-9f78-33805208a3e1.png)

I know it is a super minor thing, but it can be useful for other tools then Mercury :)