### PR TITLE
fix: rename duplicate First Name input field label to Last Name

### DIFF
--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -139,7 +139,7 @@ export function ContactSection() {
                   })
                 }
                 errorMessage={errors.lastName?.message}
-                label="First Name"
+                label="Last Name"
               />
             </div>
 


### PR DESCRIPTION
I noticed a minor issue on the bottom contact page where the "First Name" input field label was mistakenly duplicated. I have made a simple fix to replace one of the duplicate "First Name" input fields with the correct "Last Name" input field label.